### PR TITLE
Set Swift Version in Project Target

### DIFF
--- a/Instructions.xcodeproj/project.pbxproj
+++ b/Instructions.xcodeproj/project.pbxproj
@@ -741,6 +741,7 @@
 				OTHER_SWIFT_FLAGS = "$(inherited)";
 				SDKROOT = iphoneos;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 3.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
@@ -785,6 +786,7 @@
 				OTHER_SWIFT_FLAGS = "$(inherited)";
 				SDKROOT = iphoneos;
 				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
+				SWIFT_VERSION = 3.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VALIDATE_PRODUCT = YES;
 				VERSIONING_SYSTEM = "apple-generic";


### PR DESCRIPTION
I had problems building the Instructions scheme with Carthage due to a lack of SWIFT_VERSION information in the project target. Excerpt from crash log:

Build settings from command line:
 BITCODE_GENERATION_MODE = bitcode
    CARTHAGE = YES
    CODE_SIGN_IDENTITY =
    CODE_SIGNING_REQUIRED = NO
    ONLY_ACTIVE_ARCH = NO
    SDKROOT = iphoneos10.3

Check dependencies
“Swift Language Version” (SWIFT_VERSION) is required to be configured correctly for targets which use Swift.

If I now use my fork as the source (having only set the SWIFT_VERSION to Swift 3) and a create new release, everything works fine.

Xcode Version 8.3.2 (8E2002)
Swift Version 3.1 (swiftlang-802.0.53 clang-802.0.42)