### PR TITLE
Add optional parameter to FlowManager’s pause function

### DIFF
--- a/Sources/Instructions/Managers/Public/FlowManager.swift
+++ b/Sources/Instructions/Managers/Public/FlowManager.swift
@@ -91,11 +91,17 @@ public class FlowManager {
         if started && paused {
             paused = false
             createAndShowCoachMark(afterResuming: true)
+            if self.coachMarksViewController.overlayManager.overlayView.alpha == 0.0{
+                self.coachMarksViewController.overlayManager.showOverlay(true, completion: nil)
+            }
         }
     }
 
-    public func pause() {
+    public func pause(hideOverlay: Bool = false) {
         paused = true
+        if hideOverlay {
+            self.coachMarksViewController.overlayManager.showOverlay(false, completion: nil)
+        }
     }
 
     internal func reset() {


### PR DESCRIPTION
Now we can choose to hide the `overlayView` when pausing (default `false`), to make the screen animations look clean in between coach marks.