### PR TITLE
Style the status bar based on the overlay color

### DIFF
--- a/Sources/Instructions/Core/Internal/CoachMarksViewController.swift
+++ b/Sources/Instructions/Core/Internal/CoachMarksViewController.swift
@@ -67,6 +67,14 @@ class CoachMarksViewController: UIViewController {
         //swiftlint:enable force_cast
 #endif
     }
+    
+    override var preferredStatusBarStyle: UIStatusBarStyle {
+        var alpha: CGFloat = 1.0
+        var white: CGFloat = 1.0
+        overlayManager.color.getWhite(&white, alpha: &alpha)
+        
+        return white >= 0.5 ? .default : .lightContent
+    }
 
     ///
     var coachMarkDisplayManager: CoachMarkDisplayManager!


### PR DESCRIPTION
Fixes an issue where the use of a dark overlay color makes the default status bar practically invisible. For apps that use view controller-based status bar styles, this can't be overridden from the app's info.plist either.