### PR TITLE
Style the status bar based on the overlay colour

### DIFF
--- a/Sources/Instructions/Core/Internal/CoachMarksViewController.swift
+++ b/Sources/Instructions/Core/Internal/CoachMarksViewController.swift
@@ -67,6 +67,14 @@ class CoachMarksViewController: UIViewController {
         //swiftlint:enable force_cast
 #endif
     }
+    
+    override var preferredStatusBarStyle: UIStatusBarStyle {
+        var alpha: CGFloat = 1.0
+        var white: CGFloat = 1.0
+        overlayManager.color.getWhite(&white, alpha: &alpha)
+        
+        return white >= 0.5 ? .default : .lightContent
+    }
 
     ///
     var coachMarkDisplayManager: CoachMarkDisplayManager!


### PR DESCRIPTION
For apps with a dark status bar and light text, this change makes it so that their status bar stays consistent when the instructions overlay is shown.