### PR TITLE
https://github.com/ephread/Instructions/issues/90 fix

### DIFF
--- a/Sources/Instructions/Managers/Public/FlowManager.swift
+++ b/Sources/Instructions/Managers/Public/FlowManager.swift
@@ -121,9 +121,10 @@ public class FlowManager {
             self.coachMarksViewController.currentCoachMarkView?.alpha = 0.0
         }
 
-        let completionBlock = {(finished: Bool) -> Void in
-            self.coachMarksViewController.detachFromWindow()
-            if shouldCallDelegate { self.delegate?.didEndShowingBySkipping(skipped) }
+        let completionBlock = { [weak self] (finished: Bool) -> Void in
+            guard let strongSelf = self else { return }
+            strongSelf.coachMarksViewController.detachFromWindow()
+            if shouldCallDelegate { strongSelf.delegate?.didEndShowingBySkipping(skipped) }
         }
 
         if immediately {


### PR DESCRIPTION
The pull request is to address an issue mentioned in https://github.com/ephread/Instructions/issues/90

When user quickly open and close ViewController, the reference of CoachMarksViewController could be lost.

In order to rectify this, add a weak self reference and perform a check before executing the `detachFromWindow()` method.