### PR TITLE
Adds ability to customize statusBarStyle

### DIFF
--- a/Sources/Instructions/Core/Internal/CoachMarksViewController.swift
+++ b/Sources/Instructions/Core/Internal/CoachMarksViewController.swift
@@ -76,6 +76,14 @@ class CoachMarksViewController: UIViewController {
 
     ///
     weak var delegate: CoachMarksViewControllerDelegate?
+    
+    ///
+    var statusBarStyle:UIStatusBarStyle = .default
+    
+    ///
+    override var preferredStatusBarStyle : UIStatusBarStyle {
+        return statusBarStyle
+    }
 
     // MARK: - Private properties
     fileprivate var onGoingSizeChange = false
@@ -92,7 +100,6 @@ class CoachMarksViewController: UIViewController {
     fileprivate var _shouldAutorotate: Bool = true
     fileprivate var _prefersStatusBarHidden: Bool = false
     fileprivate var _supportedInterfaceOrientations: UIInterfaceOrientationMask = [.portrait]
-
     // MARK: - Lifecycle
     convenience init(coachMarkDisplayManager: CoachMarkDisplayManager,
                      skipViewDisplayManager: SkipViewDisplayManager) {

--- a/Sources/Instructions/Core/Public/CoachMarksController.swift
+++ b/Sources/Instructions/Core/Public/CoachMarksController.swift
@@ -37,6 +37,17 @@ public class CoachMarksController {
     /// be called at various points.
     public weak var delegate: CoachMarksControllerDelegate?
 
+    /// Controls the style of the status bar when coach marks are displayed
+    public var statusBarStyle:UIStatusBarStyle {
+        set(value) {
+            coachMarksViewController.statusBarStyle = value
+            coachMarksViewController.setNeedsStatusBarAppearanceUpdate()
+        }
+        get {
+            return coachMarksViewController.statusBarStyle
+        }
+    }
+    
     /// Hide the UI.
     fileprivate(set) public lazy var overlay: OverlayManager = {
         let overlay = OverlayManager()


### PR DESCRIPTION
Current implementation forces the .default status bar style when coach marks are displayed. This is inconvenient if the instructions are shown for a view who has a native status bar with light content. This commit addresses this issue and allows end user to customize the status bar style.