### PR TITLE
bugfix: the example of “transition from code” scene, the ‘tap me’ button can't fire

### DIFF
--- a/Sources/Instructions/Managers/Public/OverlayManager.swift
+++ b/Sources/Instructions/Managers/Public/OverlayManager.swift
@@ -56,9 +56,9 @@ public class OverlayManager {
 
         set {
             if newValue == true {
-                self.overlayView.holder.addGestureRecognizer(self.singleTapGestureRecognizer)
+                self.overlayView.addGestureRecognizer(self.singleTapGestureRecognizer)
             } else {
-                self.overlayView.holder.removeGestureRecognizer(self.singleTapGestureRecognizer)
+                self.overlayView.removeGestureRecognizer(self.singleTapGestureRecognizer)
             }
         }
     }

--- a/Sources/Instructions/Managers/Public/OverlayManager.swift
+++ b/Sources/Instructions/Managers/Public/OverlayManager.swift
@@ -56,9 +56,9 @@ public class OverlayManager {
 
         set {
             if newValue == true {
-                self.overlayView.addGestureRecognizer(self.singleTapGestureRecognizer)
+                self.overlayView.holder.addGestureRecognizer(self.singleTapGestureRecognizer)
             } else {
-                self.overlayView.removeGestureRecognizer(self.singleTapGestureRecognizer)
+                self.overlayView.holder.removeGestureRecognizer(self.singleTapGestureRecognizer)
             }
         }
     }

--- a/Sources/Instructions/Views/OverlayView.swift
+++ b/Sources/Instructions/Views/OverlayView.swift
@@ -45,6 +45,8 @@ class OverlayView: UIView {
 
         holder.translatesAutoresizingMaskIntoConstraints = false
         ornaments.translatesAutoresizingMaskIntoConstraints = false
+        
+        ornaments.isUserInteractionEnabled = false
 
         addSubview(holder)
         addSubview(ornaments)
@@ -61,7 +63,7 @@ class OverlayView: UIView {
     override public func hitTest(_ point: CGPoint, with event: UIEvent?) -> UIView? {
         let hitView = super.hitTest(point, with: event)
 
-        if hitView == self {
+        if hitView == self.holder {
             guard let cutoutPath = self.cutoutPath else {
                 return hitView
             }

--- a/Sources/Instructions/Views/OverlayView.swift
+++ b/Sources/Instructions/Views/OverlayView.swift
@@ -46,6 +46,7 @@ class OverlayView: UIView {
         holder.translatesAutoresizingMaskIntoConstraints = false
         ornaments.translatesAutoresizingMaskIntoConstraints = false
         
+        holder.isUserInteractionEnabled = false
         ornaments.isUserInteractionEnabled = false
 
         addSubview(holder)
@@ -63,7 +64,7 @@ class OverlayView: UIView {
     override public func hitTest(_ point: CGPoint, with event: UIEvent?) -> UIView? {
         let hitView = super.hitTest(point, with: event)
 
-        if hitView == self.holder {
+        if hitView == self {
             guard let cutoutPath = self.cutoutPath else {
                 return hitView
             }


### PR DESCRIPTION
bugfix: the example of “transition from code” scene, the ‘tap me’ button can't fire