### PR TITLE
Add previous coach mark functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -334,13 +334,17 @@ Returning `nil` will tell the `CoachMarksController` to use the defaults constra
 For more information about the skip mechanism, you can check the `Example/` directory.
 
 #### Piloting the flow from the code
-Should you ever need to programmatically show the coach mark, `CoachMarkController.flow` also provides the following method:
+Should you ever need to programmatically show the coach mark, `CoachMarkController.flow` also provides the following methods:
 
 ```swift
 func showNext(numberOfCoachMarksToSkip numberToSkip: Int = 0)
 ```
 
-You can specify a number of coach marks to skip (effectively jumping to a further index).
+```swift
+func showPrevious(numberOfCoachMarksToSkip numberToSkip: Int = 0)
+```
+
+You can specify a number of coach marks to skip (effectively jumping forward or backward to a further index).
 
 Take a look at `TransitionFromCodeViewController`, in the `Example/` directory, to get an idea of how you can leverage this method, in order to ask the user to perform certain actions.
 

--- a/Sources/Instructions/Managers/Public/FlowManager.swift
+++ b/Sources/Instructions/Managers/Public/FlowManager.swift
@@ -162,6 +162,35 @@ public class FlowManager {
             showOrStop()
         }
     }
+    
+    internal func showPreviousCoachMark(hidePrevious: Bool = true) {
+        if disableFlow || paused || !canShowCoachMark { return }
+        
+        let previousIndex = currentIndex
+        
+        canShowCoachMark = false
+        currentIndex -= 1
+        
+        if currentIndex < 0 {
+            stopFlow()
+            return
+        }
+        
+        if let currentCoachMark = currentCoachMark {
+            delegate?.willHide(coachMark: currentCoachMark, at: currentIndex + 1)
+        }
+        
+        if hidePrevious {
+            guard let currentCoachMark = currentCoachMark else { return }
+            
+            coachMarksViewController.hide(coachMark: currentCoachMark, at: previousIndex) {
+                self.delegate?.didHide(coachMark: self.currentCoachMark!, at: self.currentIndex)
+                self.showOrStop()
+            }
+        } else {
+            showOrStop()
+        }
+    }
 
     internal func showOrStop() {
         if self.currentIndex < self.numberOfCoachMarks {

--- a/Sources/Instructions/Managers/Public/FlowManager.swift
+++ b/Sources/Instructions/Managers/Public/FlowManager.swift
@@ -302,6 +302,24 @@ public class FlowManager {
 
         showNextCoachMark(hidePrevious: true)
     }
+    
+    /// Show the previous specified Coach Mark.
+    ///
+    /// - Parameter numberOfCoachMarksToSkip: the number of coach marks
+    ///                                       to skip.
+    public func showPrevious(numberOfCoachMarksToSkip numberToSkip: Int = 0) {
+        if !self.started || !canShowCoachMark { return }
+        
+        if numberToSkip < 0 {
+            print("showPrevious: The specified number of coach marks to skip" +
+                  "was negative, nothing to do.")
+            return
+        }
+        
+        currentIndex -= numberToSkip
+        
+        showPreviousCoachMark(hidePrevious: true)
+    }
 }
 
 extension FlowManager: CoachMarksViewControllerDelegate {


### PR DESCRIPTION
### Checklist for this pull request

- [X] I have read the [guidelines for contributing](../CONTRIBUTING.md).
- [X] I have updated README.md, describing the new feature I'm adding (if applicable).
- [X] I have checked that my code additions did fail neither code linting checks nor unit/UI test.

### Description
As discussed in issue #113, this adds a public showPrevious method to show the previous coach mark.
Code style has been maintained, the two methods were copied as templates from existing methods.