### PR TITLE
fix `spec.swift_version`

### DIFF
--- a/Instructions.podspec
+++ b/Instructions.podspec
@@ -9,7 +9,7 @@ Pod::Spec.new do |spec|
   spec.author           = { "Frédéric Maquin" => "fred@ephread.com" }
   spec.source           = { :git => "https://github.com/ephread/Instructions.git", :tag => spec.version.to_s }
 
-  spec.swift_version    = '5'
+  spec.swift_version    = '5.0'
   spec.platform         = :ios, '9.0'
   spec.requires_arc     = true
 

--- a/InstructionsAppExtensions.podspec
+++ b/InstructionsAppExtensions.podspec
@@ -9,7 +9,7 @@ Pod::Spec.new do |spec|
   spec.author           = { "Frédéric Maquin" => "fred@ephread.com" }
   spec.source           = { :git => "https://github.com/ephread/Instructions.git", :tag => spec.version.to_s }
 
-  spec.swift_version    = '5'
+  spec.swift_version    = '5.0'
   spec.platform         = :ios, '9.0'
   spec.requires_arc     = true
 


### PR DESCRIPTION
### Checklist for this pull request

- [x] I have read the [guidelines for contributing](../CONTRIBUTING.md).
- [x] I have updated README.md, describing the new feature I'm adding (if applicable).
- [x] I have checked that my code additions did fail neither code linting checks nor unit/UI test.

### Description

`swift_version` must be set to `5.0` instead of `5`, otherwise Xcode will still show the `Instructions.framework` target as available for conversion to Swift 5...
