### PR TITLE
Add Swift Package Manager Support for Xcode 11

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,27 +1,15 @@
-// Package.swift
-//
-// Copyright (c) 2016 Frédéric Maquin <fred@ephread.com>
-//
-// Permission is hereby granted, free of charge, to any person obtaining a copy
-// of this software and associated documentation files (the "Software"), to deal
-// in the Software without restriction, including without limitation the rights
-// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-// copies of the Software, and to permit persons to whom the Software is
-// furnished to do so, subject to the following conditions:
-//
-// The above copyright notice and this permission notice shall be included in
-// all copies or substantial portions of the Software.
-//
-// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-// THE SOFTWARE.
-
+// swift-tools-version:5.1
 import PackageDescription
 
 let package = Package(
-  name: "Instructions"
+    name: "Instructions",
+    platforms: [
+        .iOS(.v9),
+    ],
+    products: [
+        .library(name: "Instructions", targets: ["Instructions"]),
+    ],
+    targets: [
+        .target(name: "Instructions")
+    ]
 )


### PR DESCRIPTION
### Checklist for this pull request

- [x] I have read the [guidelines for contributing](../CONTRIBUTING.md).
- [x] I have updated README.md, describing the new feature I'm adding (if applicable).
- [x] I have checked that my code additions did fail neither code linting checks nor unit/UI test.

### Description

Updates Package.swift in order to work as a iOS dependency via SPM in Xcode 11
