### PR TITLE
Allow having a point of interest without a cutout area

### DIFF
--- a/Sources/Instructions/Helpers/Public/CoachMarkHelper.swift
+++ b/Sources/Instructions/Helpers/Public/CoachMarkHelper.swift
@@ -162,9 +162,16 @@ public class CoachMarkHelper {
         in superview: UIView?
     ) -> CoachMark {
         var coachMark = CoachMark()
+        
+        let frame: CGRect?
+        if let point = pointOfInterest {
+            frame = .init(origin: point, size: .zero)
+        } else {
+            frame = nil
+        }
 
         update(coachMark: &coachMark,
-               usingFrame: nil,
+               usingFrame: frame,
                pointOfInterest: pointOfInterest,
                superview: superview,
                cutoutPathMaker: nil)


### PR DESCRIPTION
Currently when one invokes `CoachMarkHelper.makeCoachMark(pointOfInterest:in:)` the view is then not placed pointing the point of interest but instead ignores it.

This is a quick fix using the following idea:
https://github.com/ephread/Instructions/issues/83#issuecomment-261511352

Probably it is not the best way to handle this and something more needs to be done internally so any ideas and contributions directly to this PR are welcome, I am just not too familiar with the source code.