### PR TITLE
Fix iOS 15 Layout for CoachMarkBodyDefaultView

### DIFF
--- a/Sources/Instructions/Extra/Default Views/CoachMarkBodyDefaultView.swift
+++ b/Sources/Instructions/Extra/Default Views/CoachMarkBodyDefaultView.swift
@@ -116,7 +116,7 @@ private extension CoachMarkBodyDefaultView {
         textView.isScrollEnabled = false
         textView.isUserInteractionEnabled = false
 
-        textView.setContentCompressionResistancePriority(UILayoutPriority.required,
+        textView.setContentCompressionResistancePriority(.init(749),
                                                          for: .horizontal)
         textView.setContentCompressionResistancePriority(UILayoutPriority.required,
                                                          for: .vertical)
@@ -135,9 +135,9 @@ private extension CoachMarkBodyDefaultView {
 
         label.isUserInteractionEnabled = false
 
-        label.setContentCompressionResistancePriority(UILayoutPriority.required, for: .horizontal)
+        label.setContentCompressionResistancePriority(.init(750), for: .horizontal)
         label.setContentCompressionResistancePriority(UILayoutPriority.required, for: .vertical)
-        label.setContentHuggingPriority(UILayoutPriority.required, for: .horizontal)
+        label.setContentHuggingPriority(.init(760), for: .horizontal)
         label.setContentHuggingPriority(UILayoutPriority.defaultLow, for: .vertical)
 
         return label

--- a/Sources/Instructions/Extra/Default Views/CoachMarkBodyDefaultView.swift
+++ b/Sources/Instructions/Extra/Default Views/CoachMarkBodyDefaultView.swift
@@ -116,12 +116,20 @@ private extension CoachMarkBodyDefaultView {
         textView.isScrollEnabled = false
         textView.isUserInteractionEnabled = false
 
-        textView.setContentCompressionResistancePriority(.init(749),
-                                                         for: .horizontal)
+        if #available(iOS 15.0, *) {
+            textView.setContentCompressionResistancePriority(UILayoutPriority.defaultHigh - 1,
+                                                             for: .horizontal)
+        } else {
+            textView.setContentCompressionResistancePriority(UILayoutPriority.required,
+                                                             for: .horizontal)
+        }
+
         textView.setContentCompressionResistancePriority(UILayoutPriority.required,
                                                          for: .vertical)
-        textView.setContentHuggingPriority(UILayoutPriority.defaultHigh, for: .horizontal)
-        textView.setContentHuggingPriority(UILayoutPriority.defaultHigh, for: .vertical)
+        textView.setContentHuggingPriority(UILayoutPriority.defaultHigh,
+                                           for: .horizontal)
+        textView.setContentHuggingPriority(UILayoutPriority.defaultHigh,
+                                           for: .vertical)
 
         return textView
     }
@@ -135,10 +143,22 @@ private extension CoachMarkBodyDefaultView {
 
         label.isUserInteractionEnabled = false
 
-        label.setContentCompressionResistancePriority(.init(750), for: .horizontal)
-        label.setContentCompressionResistancePriority(UILayoutPriority.required, for: .vertical)
-        label.setContentHuggingPriority(.init(760), for: .horizontal)
-        label.setContentHuggingPriority(UILayoutPriority.defaultLow, for: .vertical)
+        if #available(iOS 15.0, *) {
+            label.setContentCompressionResistancePriority(UILayoutPriority.defaultHigh,
+                                                          for: .horizontal)
+            label.setContentHuggingPriority(UILayoutPriority.init(765),
+                                            for: .horizontal)
+        } else {
+            label.setContentCompressionResistancePriority(UILayoutPriority.required,
+                                                          for: .horizontal)
+            label.setContentHuggingPriority(UILayoutPriority.defaultLow,
+                                            for: .horizontal)
+        }
+
+        label.setContentCompressionResistancePriority(UILayoutPriority.required,
+                                                      for: .vertical)
+        label.setContentHuggingPriority(UILayoutPriority.defaultLow,
+                                        for: .vertical)
 
         return label
     }


### PR DESCRIPTION
The layout of the stack view inside CoachMarkBodyDefaultView is broken on iOS 15, the "Next Label" does not appear properly. This is due to a change in the internal Auto Layout workings of UIStackView. See this blog post for more info:

https://useyourloaf.com/blog/stack-view-changes-in-ios-15/

This PR introduces a fix for said layout issue.