### PR TITLE
Add next label position

### DIFF
--- a/Sources/Instructions/Extra/Default Views/CoachMarkBodyDefaultView.swift
+++ b/Sources/Instructions/Extra/Default Views/CoachMarkBodyDefaultView.swift
@@ -24,7 +24,7 @@ public class CoachMarkBodyDefaultView: UIControl,
     public lazy var nextLabel: UILabel = makeNextLabel()
     public lazy var hintLabel: UITextView = makeHintTextView()
     public lazy var separator: UIView = makeSeparator()
-    private let nextLabelPosition: CoachMarkNextLabelPosition?
+    private var nextLabelPosition: CoachMarkNextLabelPosition = .trailing
     private let spacing: CGFloat = 18
 
     public var background: CoachMarkBodyBackgroundStyle {
@@ -42,13 +42,11 @@ public class CoachMarkBodyDefaultView: UIControl,
 
     // MARK: - Initialization
     override public init(frame: CGRect) {
-        self.nextLabelPosition = .none
-
         super.init(frame: frame)
         initializeViewHierarchy()
     }
 
-    public init(frame: CGRect, hintText: String, nextText: String?, nextLabelPosition: CoachMarkNextLabelPosition?) {
+    public init(frame: CGRect, hintText: String, nextText: String?, nextLabelPosition: CoachMarkNextLabelPosition) {
         self.nextLabelPosition = nextLabelPosition
 
         super.init(frame: frame)
@@ -61,18 +59,18 @@ public class CoachMarkBodyDefaultView: UIControl,
         hintLabel.text = hintText
     }
 
-    public init(frame: CGRect, nextLabelPosition: CoachMarkNextLabelPosition?) {
+    public init(frame: CGRect, nextLabelPosition: CoachMarkNextLabelPosition) {
         self.nextLabelPosition = nextLabelPosition
 
         super.init(frame: frame)
         initializeViewHierarchy()
     }
 
-    convenience public init(hintText: String, nextText: String?, nextLabelPosition: CoachMarkNextLabelPosition?) {
+    convenience public init(hintText: String, nextText: String?, nextLabelPosition: CoachMarkNextLabelPosition) {
         self.init(frame: CGRect.zero, hintText: hintText, nextText: nextText, nextLabelPosition: nextLabelPosition)
     }
 
-    convenience public init(nextLabelPosition: CoachMarkNextLabelPosition?) {
+    convenience public init(nextLabelPosition: CoachMarkNextLabelPosition) {
         self.init(frame: CGRect.zero, nextLabelPosition: nextLabelPosition)
     }
 
@@ -96,7 +94,19 @@ private extension CoachMarkBodyDefaultView {
         labelStackView.fillSuperview(insets: UIEdgeInsets(top: 10, left: 15, bottom: 10, right: 15))
 
         switch nextLabelPosition {
-        case .topRight:
+        case .trailing:
+            labelStackView.addArrangedSubview(hintLabel)
+            labelStackView.addArrangedSubview(separator)
+            labelStackView.addArrangedSubview(nextLabel)
+            separator.heightAnchor.constraint(equalTo: labelStackView.heightAnchor,
+                                              constant: -10).isActive = true
+        case .leading:
+            labelStackView.addArrangedSubview(nextLabel)
+            labelStackView.addArrangedSubview(separator)
+            labelStackView.addArrangedSubview(hintLabel)
+            separator.heightAnchor.constraint(equalTo: labelStackView.heightAnchor,
+                                              constant: -10).isActive = true
+        case .topTrailing:
             labelStackView.addSubview(hintLabel)
             labelStackView.addSubview(nextLabel)
 
@@ -108,7 +118,7 @@ private extension CoachMarkBodyDefaultView {
                 hintLabel.leftAnchor.constraint(equalTo: leftAnchor, constant: spacing),
                 hintLabel.rightAnchor.constraint(lessThanOrEqualTo: rightAnchor, constant: -spacing)
             ])
-        case .topLeft:
+        case .topLeading:
             labelStackView.addSubview(hintLabel)
             labelStackView.addSubview(nextLabel)
 
@@ -120,7 +130,7 @@ private extension CoachMarkBodyDefaultView {
                 hintLabel.leftAnchor.constraint(equalTo: leftAnchor, constant: spacing),
                 hintLabel.rightAnchor.constraint(lessThanOrEqualTo: rightAnchor, constant: -spacing)
             ])
-        case .bottomRight:
+        case .bottomTrailing:
             labelStackView.addSubview(hintLabel)
             labelStackView.addSubview(nextLabel)
 
@@ -132,7 +142,7 @@ private extension CoachMarkBodyDefaultView {
                 nextLabel.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -spacing),
                 nextLabel.rightAnchor.constraint(equalTo: rightAnchor, constant: -spacing)
             ])
-        case .bottomLeft:
+        case .bottomLeading:
             labelStackView.addSubview(hintLabel)
             labelStackView.addSubview(nextLabel)
 
@@ -144,13 +154,6 @@ private extension CoachMarkBodyDefaultView {
                 nextLabel.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -spacing),
                 nextLabel.leftAnchor.constraint(equalTo: leftAnchor, constant: spacing)
             ])
-        case .none:
-            labelStackView.addArrangedSubview(hintLabel)
-            labelStackView.addArrangedSubview(separator)
-            labelStackView.addArrangedSubview(nextLabel)
-
-            separator.heightAnchor.constraint(equalTo: labelStackView.heightAnchor,
-                                              constant: -10).isActive = true
         }
     }
 

--- a/Sources/Instructions/Extra/Default Views/CoachMarkBodyDefaultView.swift
+++ b/Sources/Instructions/Extra/Default Views/CoachMarkBodyDefaultView.swift
@@ -24,6 +24,8 @@ public class CoachMarkBodyDefaultView: UIControl,
     public lazy var nextLabel: UILabel = makeNextLabel()
     public lazy var hintLabel: UITextView = makeHintTextView()
     public lazy var separator: UIView = makeSeparator()
+    private let nextLabelPosition: CoachMarkNextLabelPosition?
+    private let spacing: CGFloat = 18
 
     public var background: CoachMarkBodyBackgroundStyle {
         get { return bodyBackground }
@@ -40,11 +42,15 @@ public class CoachMarkBodyDefaultView: UIControl,
 
     // MARK: - Initialization
     override public init(frame: CGRect) {
+        self.nextLabelPosition = .none
+
         super.init(frame: frame)
         initializeViewHierarchy()
     }
 
-    public init(frame: CGRect, hintText: String, nextText: String?) {
+    public init(frame: CGRect, hintText: String, nextText: String?, nextLabelPosition: CoachMarkNextLabelPosition?) {
+        self.nextLabelPosition = nextLabelPosition
+
         super.init(frame: frame)
         initializeViewHierarchy()
 
@@ -55,12 +61,19 @@ public class CoachMarkBodyDefaultView: UIControl,
         hintLabel.text = hintText
     }
 
-    convenience public init(hintText: String, nextText: String?) {
-        self.init(frame: CGRect.zero, hintText: hintText, nextText: nextText)
+    public init(frame: CGRect, nextLabelPosition: CoachMarkNextLabelPosition?) {
+        self.nextLabelPosition = nextLabelPosition
+
+        super.init(frame: frame)
+        initializeViewHierarchy()
     }
 
-    convenience public init() {
-        self.init(frame: CGRect.zero)
+    convenience public init(hintText: String, nextText: String?, nextLabelPosition: CoachMarkNextLabelPosition?) {
+        self.init(frame: CGRect.zero, hintText: hintText, nextText: nextText, nextLabelPosition: nextLabelPosition)
+    }
+
+    convenience public init(nextLabelPosition: CoachMarkNextLabelPosition?) {
+        self.init(frame: CGRect.zero, nextLabelPosition: nextLabelPosition)
     }
 
     required public init?(coder aDecoder: NSCoder) {
@@ -82,12 +95,63 @@ private extension CoachMarkBodyDefaultView {
         bodyBackground.fillSuperview()
         labelStackView.fillSuperview(insets: UIEdgeInsets(top: 10, left: 15, bottom: 10, right: 15))
 
-        labelStackView.addArrangedSubview(hintLabel)
-        labelStackView.addArrangedSubview(separator)
-        labelStackView.addArrangedSubview(nextLabel)
+        switch nextLabelPosition {
+        case .topRight:
+            labelStackView.addSubview(hintLabel)
+            labelStackView.addSubview(nextLabel)
 
-        separator.heightAnchor.constraint(equalTo: labelStackView.heightAnchor,
-                                          constant: -10).isActive = true
+            NSLayoutConstraint.activate([
+                nextLabel.topAnchor.constraint(equalTo: topAnchor, constant: spacing),
+                nextLabel.bottomAnchor.constraint(equalTo: hintLabel.topAnchor, constant: -spacing),
+                nextLabel.rightAnchor.constraint(equalTo: rightAnchor, constant: -spacing),
+                hintLabel.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -spacing),
+                hintLabel.leftAnchor.constraint(equalTo: leftAnchor, constant: spacing),
+                hintLabel.rightAnchor.constraint(lessThanOrEqualTo: rightAnchor, constant: -spacing)
+            ])
+        case .topLeft:
+            labelStackView.addSubview(hintLabel)
+            labelStackView.addSubview(nextLabel)
+
+            NSLayoutConstraint.activate([
+                nextLabel.topAnchor.constraint(equalTo: topAnchor, constant: spacing),
+                nextLabel.bottomAnchor.constraint(equalTo: hintLabel.topAnchor, constant: -spacing),
+                nextLabel.leftAnchor.constraint(equalTo: leftAnchor, constant: spacing),
+                hintLabel.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -spacing),
+                hintLabel.leftAnchor.constraint(equalTo: leftAnchor, constant: spacing),
+                hintLabel.rightAnchor.constraint(lessThanOrEqualTo: rightAnchor, constant: -spacing)
+            ])
+        case .bottomRight:
+            labelStackView.addSubview(hintLabel)
+            labelStackView.addSubview(nextLabel)
+
+            NSLayoutConstraint.activate([
+                hintLabel.topAnchor.constraint(equalTo: topAnchor, constant: spacing),
+                hintLabel.bottomAnchor.constraint(equalTo: nextLabel.topAnchor, constant: -spacing),
+                hintLabel.leftAnchor.constraint(equalTo: leftAnchor, constant: spacing),
+                hintLabel.rightAnchor.constraint(lessThanOrEqualTo: rightAnchor, constant: -spacing),
+                nextLabel.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -spacing),
+                nextLabel.rightAnchor.constraint(equalTo: rightAnchor, constant: -spacing)
+            ])
+        case .bottomLeft:
+            labelStackView.addSubview(hintLabel)
+            labelStackView.addSubview(nextLabel)
+
+            NSLayoutConstraint.activate([
+                hintLabel.topAnchor.constraint(equalTo: topAnchor, constant: spacing),
+                hintLabel.bottomAnchor.constraint(equalTo: nextLabel.topAnchor, constant: -spacing),
+                hintLabel.leftAnchor.constraint(equalTo: leftAnchor, constant: spacing),
+                hintLabel.rightAnchor.constraint(lessThanOrEqualTo: rightAnchor, constant: -spacing),
+                nextLabel.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -spacing),
+                nextLabel.leftAnchor.constraint(equalTo: leftAnchor, constant: spacing)
+            ])
+        case .none:
+            labelStackView.addArrangedSubview(hintLabel)
+            labelStackView.addArrangedSubview(separator)
+            labelStackView.addArrangedSubview(nextLabel)
+
+            separator.heightAnchor.constraint(equalTo: labelStackView.heightAnchor,
+                                              constant: -10).isActive = true
+        }
     }
 
     func initializeAccessibilityIdentifier() {

--- a/Sources/Instructions/Helpers/Public/CoachMarkHelper.swift
+++ b/Sources/Instructions/Helpers/Public/CoachMarkHelper.swift
@@ -28,15 +28,16 @@ public class CoachMarkHelper {
     public func makeDefaultCoachViews(
         withArrow arrow: Bool = true,
         withNextText nextText: Bool = true,
-        arrowOrientation: CoachMarkArrowOrientation? = .top
+        arrowOrientation: CoachMarkArrowOrientation? = .top,
+        nextLabelPosition: CoachMarkNextLabelPosition? = .none
     ) -> (bodyView: CoachMarkBodyDefaultView, arrowView: CoachMarkArrowDefaultView?) {
 
         var coachMarkBodyView: CoachMarkBodyDefaultView
 
         if nextText {
-            coachMarkBodyView = CoachMarkBodyDefaultView()
+            coachMarkBodyView = CoachMarkBodyDefaultView(nextLabelPosition: nextLabelPosition)
         } else {
-            coachMarkBodyView = CoachMarkBodyDefaultView(hintText: "", nextText: nil)
+            coachMarkBodyView = CoachMarkBodyDefaultView(hintText: "", nextText: nil, nextLabelPosition: .none)
         }
 
         var coachMarkArrowView: CoachMarkArrowDefaultView?
@@ -61,9 +62,10 @@ public class CoachMarkHelper {
         withArrow arrow: Bool = true,
         arrowOrientation: CoachMarkArrowOrientation? = .top,
         hintText: String,
-        nextText: String? = nil
+        nextText: String? = nil,
+        nextLabelPosition: CoachMarkNextLabelPosition? = .none
     ) -> (bodyView: CoachMarkBodyDefaultView, arrowView: CoachMarkArrowDefaultView?) {
-        let coachMarkBodyView = CoachMarkBodyDefaultView(hintText: hintText, nextText: nextText)
+        let coachMarkBodyView = CoachMarkBodyDefaultView(hintText: hintText, nextText: nextText, nextLabelPosition: nextLabelPosition)
 
         var coachMarkArrowView: CoachMarkArrowDefaultView?
 

--- a/Sources/Instructions/Helpers/Public/CoachMarkHelper.swift
+++ b/Sources/Instructions/Helpers/Public/CoachMarkHelper.swift
@@ -29,7 +29,7 @@ public class CoachMarkHelper {
         withArrow arrow: Bool = true,
         withNextText nextText: Bool = true,
         arrowOrientation: CoachMarkArrowOrientation? = .top,
-        nextLabelPosition: CoachMarkNextLabelPosition? = .none
+        nextLabelPosition: CoachMarkNextLabelPosition = .trailing
     ) -> (bodyView: CoachMarkBodyDefaultView, arrowView: CoachMarkArrowDefaultView?) {
 
         var coachMarkBodyView: CoachMarkBodyDefaultView
@@ -37,7 +37,7 @@ public class CoachMarkHelper {
         if nextText {
             coachMarkBodyView = CoachMarkBodyDefaultView(nextLabelPosition: nextLabelPosition)
         } else {
-            coachMarkBodyView = CoachMarkBodyDefaultView(hintText: "", nextText: nil, nextLabelPosition: .none)
+            coachMarkBodyView = CoachMarkBodyDefaultView(hintText: "", nextText: nil, nextLabelPosition: nextLabelPosition)
         }
 
         var coachMarkArrowView: CoachMarkArrowDefaultView?
@@ -63,7 +63,7 @@ public class CoachMarkHelper {
         arrowOrientation: CoachMarkArrowOrientation? = .top,
         hintText: String,
         nextText: String? = nil,
-        nextLabelPosition: CoachMarkNextLabelPosition? = .none
+        nextLabelPosition: CoachMarkNextLabelPosition = .trailing
     ) -> (bodyView: CoachMarkBodyDefaultView, arrowView: CoachMarkArrowDefaultView?) {
         let coachMarkBodyView = CoachMarkBodyDefaultView(hintText: hintText, nextText: nextText, nextLabelPosition: nextLabelPosition)
 

--- a/Sources/Instructions/Helpers/Public/Enums/CoachMarkNextLabelPosition.swift
+++ b/Sources/Instructions/Helpers/Public/Enums/CoachMarkNextLabelPosition.swift
@@ -1,0 +1,6 @@
+public enum CoachMarkNextLabelPosition {
+    case topRight
+    case topLeft
+    case bottomRight
+    case bottomLeft
+}

--- a/Sources/Instructions/Helpers/Public/Enums/CoachMarkNextLabelPosition.swift
+++ b/Sources/Instructions/Helpers/Public/Enums/CoachMarkNextLabelPosition.swift
@@ -1,6 +1,14 @@
+// Copyright (c) 2015-present Frédéric Maquin <fred@ephread.com> and contributors.
+// Licensed under the terms of the MIT License.
+
+/// Available positions for the nextLabel.
+/// A nextLabel can either be positioned right beside the hintLabel (.trailing / .leading) with a separator in between, or
+/// be positioned at the corner of the body (.topTrailing / .topLeading / .bottomTrailing / .bottomLeading) without a separator.
 public enum CoachMarkNextLabelPosition {
-    case topRight
-    case topLeft
-    case bottomRight
-    case bottomLeft
+    case trailing
+    case leading
+    case topTrailing
+    case topLeading
+    case bottomTrailing
+    case bottomLeading
 }


### PR DESCRIPTION
## Motivation & Context
> Can the "next" control be at the bottom right corner of each coach mark screen? #272

## Desctiption
- Added options to set the position of `nextLabel` :
  - trailing (default)
  - leading
  - topTrailing
  - topLeading
  - bottomTrailing
  - bottomLeading

- Example: 
```swift
    func coachMarksController(
        _ coachMarksController: CoachMarksController,
        coachMarkViewsAt index: Int,
        madeFrom coachMark: CoachMark
    ) -> (bodyView: UIView & CoachMarkBodyView, arrowView: (UIView & CoachMarkArrowView)?) {
        let coachViews = coachMarksController.helper.makeDefaultCoachViews(
            withArrow: true,
            arrowOrientation: coachMark.arrowOrientation,
            nextLabelPosition: .trailing // .leading .topTrailing .topLeading .bottomTrailing .bottomLeading
        )

        coachViews.bodyView.hintLabel.text = "Hello! \n\nI'm a Coach Mark!"
        coachViews.bodyView.nextLabel.text = "Ok!"

        return (bodyView: coachViews.bodyView, arrowView: coachViews.arrowView)
    }
```
|trailing(default)|leading|
|--|--|
|<img width="200" src="https://user-images.githubusercontent.com/82751283/170323476-d9ea52f1-fe03-420e-b75b-f57db775cdb2.png">|<img width="200" src="https://user-images.githubusercontent.com/82751283/170323550-1f2014e2-606c-4304-823b-16f0d64b9e3f.png">|

|topTrailing|topLeading|bottomTrailing|bottomLeading|
|--|--|--|--|
|<img width="200" src="https://user-images.githubusercontent.com/82751283/168028825-6d552530-f083-4612-a866-93ed71abfe21.png">|<img width="200" src="https://user-images.githubusercontent.com/82751283/168028812-73f160c6-4b76-4a88-9736-4cfef7215610.png">|<img width="200"  src="https://user-images.githubusercontent.com/82751283/168028822-7e29658b-d06a-40c0-a5a1-2b161eccbded.png">|<img width="200" src="https://user-images.githubusercontent.com/82751283/168028819-fc3c5b92-616e-4c9b-9677-6db8fe3a877c.png">|
