### PR TITLE
Convert stored properties into computed properties

### DIFF
--- a/Sources/Instructions/Managers/Public/FlowManager.swift
+++ b/Sources/Instructions/Managers/Public/FlowManager.swift
@@ -294,10 +294,10 @@ public class FlowManager {
 
     // MARK: Renamed Public Properties
     @available(*, unavailable, renamed: "isStarted")
-    public var started: Bool = false
+    public var started: Bool { return false }
 
     @available(*, unavailable, renamed: "isPaused")
-    public var paused: Bool = false
+    public var paused: Bool { return false }
 }
 
 extension FlowManager: CoachMarksViewControllerDelegate {

--- a/Sources/Instructions/Managers/Public/OverlayManager.swift
+++ b/Sources/Instructions/Managers/Public/OverlayManager.swift
@@ -189,16 +189,16 @@ public class OverlayManager {
 
     // MARK: Renamed Public Properties
     @available(*, unavailable, renamed: "backgroundColor")
-    public var color: UIColor = InstructionsColor.overlay
+    public var color: UIColor { return InstructionsColor.overlay }
 
     @available(*, unavailable, renamed: "isUserInteractionEnabled")
-    public var allowTap: Bool = true
+    public var allowTap: Bool { return true }
 
     @available(*, unavailable, renamed: "isUserInteractionEnabledInsideCutoutPath")
-    public var allowTouchInsideCutoutPath: Bool = false
+    public var allowTouchInsideCutoutPath: Bool { return false }
 
     @available(*, unavailable, renamed: "areTouchEventsForwarded")
-    public var forwardTouchEvents: Bool = false
+    public var forwardTouchEvents: Bool { return false }
 }
 
 // swiftlint:disable class_delegate_protocol


### PR DESCRIPTION
This PR addresses a compiler error in Xcode 15.0 Beta, which states:
> Stored properties cannot be marked potentially unavailable with '@available'

Since use of such properties is inhibited through a compiler error, I've simply replaced the stored properties marked as unavailable with computed properties that are returning the same result they're returning now.