### PR TITLE
Changed the FlowManager.currentIndex getter to public

### DIFF
--- a/Sources/Instructions/Managers/Public/FlowManager.swift
+++ b/Sources/Instructions/Managers/Public/FlowManager.swift
@@ -8,6 +8,9 @@ public class FlowManager {
     /// `true` if coach marks are currently being displayed, `false` otherwise.
     public var isStarted: Bool { return currentIndex > -1 }
 
+    /// The index (in `coachMarks`) of the coach mark being currently displayed.
+    private(set) public var currentIndex = -1
+    
     /// Sometimes, the chain of coach mark display can be paused
     /// to let animations be performed. `true` to pause the execution,
     /// `false` otherwise.
@@ -48,9 +51,6 @@ public class FlowManager {
     ///
     /// `true` if a new coach mark can be shown, `false` otherwise.
     private var canShowCoachMark = true
-
-    /// The index (in `coachMarks`) of the coach mark being currently displayed.
-    internal var currentIndex = -1
 
     init(coachMarksViewController: CoachMarksViewController) {
         self.coachMarksViewController = coachMarksViewController


### PR DESCRIPTION
This PR exposes the `FlowManager.currentIndex` getter, while keeping the setter private.

This allows us to reference the flows current index which is required in some of our more advanced workflows.