### PR TITLE
Fix patternImage color overlay

### DIFF
--- a/Sources/Instructions/Managers/Internal/OverlayStyleManager/TranslucentOverlayStyleManager.swift
+++ b/Sources/Instructions/Managers/Internal/OverlayStyleManager/TranslucentOverlayStyleManager.swift
@@ -68,14 +68,7 @@ class TranslucentOverlayStyleManager: OverlayStyleManager {
             if show {
                 self.overlayLayer.removeFromSuperlayer()
                 self.overlayLayer.frame = overlay.bounds
-                /*
-                  Fix for flipped origins: iOS (top-left) vs CG (bottom-left).
-                  Applies to gradient images from `init(patternImage:)`.
-                  Non-gradient images as background must not be used
-                */
-                if type(of: self.color) == NSClassFromString("UIDynamicPatternColor") {
-                    self.overlayLayer.transform = CATransform3DMakeScale(1, -1, 1)
-                }
+                self.fixColorFromPatternImageIfNeeded(for: self.overlayLayer)
                 self.overlayLayer.backgroundColor = self.color.cgColor
                 overlay.holder.layer.addSublayer(self.overlayLayer)
                 overlay.holder.backgroundColor = UIColor.clear
@@ -130,6 +123,7 @@ class TranslucentOverlayStyleManager: OverlayStyleManager {
 
         let maskLayer = CALayer()
         maskLayer.frame = overlayLayer.bounds
+        fixColorFromPatternImageIfNeeded(for: self.cutoutMaskLayer)
         maskLayer.addSublayer(self.cutoutMaskLayer)
         maskLayer.addSublayer(self.fullMaskLayer)
 
@@ -167,5 +161,17 @@ class TranslucentOverlayStyleManager: OverlayStyleManager {
         layer.name = OverlayView.sublayerName
 
         return layer
+    }
+    
+    /*
+      // Adjust for flipped origins between CG and iOS.
+      // iOS origin: top left. CG origin: bottom left.
+      // This fix ensures proper rendering of gradient images and cutout layers
+      // created with `init(patternImage image: UIImage)`.
+    */
+    private func fixColorFromPatternImageIfNeeded(for layer: CALayer) {
+        if type(of: self.color) == NSClassFromString("UIDynamicPatternColor") {
+            layer.transform = CATransform3DMakeScale(1, -1, 1)
+        }
     }
 }

--- a/Sources/Instructions/Managers/Internal/OverlayStyleManager/TranslucentOverlayStyleManager.swift
+++ b/Sources/Instructions/Managers/Internal/OverlayStyleManager/TranslucentOverlayStyleManager.swift
@@ -68,6 +68,14 @@ class TranslucentOverlayStyleManager: OverlayStyleManager {
             if show {
                 self.overlayLayer.removeFromSuperlayer()
                 self.overlayLayer.frame = overlay.bounds
+                /*
+                  Fix for flipped origins: iOS (top-left) vs CG (bottom-left).
+                  Applies to gradient images from `init(patternImage:)`.
+                  Non-gradient images as background must not be used
+                */
+                if type(of: self.color) == NSClassFromString("UIDynamicPatternColor") {
+                    self.overlayLayer.transform = CATransform3DMakeScale(1, -1, 1)
+                }
                 self.overlayLayer.backgroundColor = self.color.cgColor
                 overlay.holder.layer.addSublayer(self.overlayLayer)
                 overlay.holder.backgroundColor = UIColor.clear


### PR DESCRIPTION
Adjust for flipped origins between CG and iOS.
iOS origin: top left. CG origin: bottom left.
This fix ensures proper rendering of gradient images and cutout layers
created with `init(patternImage image: UIImage)`.