### PR TITLE
Fix: computeOrientation for case pointOfInterest has big heigh

### DIFF
--- a/Sources/Instructions/Core/Public/CoachMark.swift
+++ b/Sources/Instructions/Core/Public/CoachMark.swift
@@ -83,7 +83,7 @@ public struct CoachMark {
             return
         }
 
-        if cutoutPath.bounds.origin.y > frame.size.height / 2 {
+        if (cutoutPath.bounds.origin.y + cutoutPath.bounds.height) > frame.size.height / 2 {
             self.arrowOrientation = .bottom
         } else {
             self.arrowOrientation = .top

--- a/Sources/Instructions/Core/Public/CoachMark.swift
+++ b/Sources/Instructions/Core/Public/CoachMark.swift
@@ -83,7 +83,7 @@ public struct CoachMark {
             return
         }
 
-        if (cutoutPath.bounds.origin.y + cutoutPath.bounds.height) > frame.size.height / 2 {
+        if (cutoutPath.bounds.origin.y + cutoutPath.bounds.height) > (frame.size.height - 300) {
             self.arrowOrientation = .bottom
         } else {
             self.arrowOrientation = .top

--- a/Sources/Instructions/Core/Public/CoachMark.swift
+++ b/Sources/Instructions/Core/Public/CoachMark.swift
@@ -83,7 +83,9 @@ public struct CoachMark {
             return
         }
 
-        if (cutoutPath.bounds.origin.y + cutoutPath.bounds.height) > (frame.size.height - 300) {
+        let top = cutoutPath.bounds.origin.y
+        let bottom = frame.size.height - cutoutPath.bounds.origin.y - cutoutPath.bounds.height
+        if top > bottom {
             self.arrowOrientation = .bottom
         } else {
             self.arrowOrientation = .top


### PR DESCRIPTION
Need to calculate free space at top and bottom to place popup more reasonably

![Simulator Screenshot - iPhone SE (3rd generation) - 2024-11-08 at 09 39 03](https://github.com/user-attachments/assets/45012352-7a42-4576-8957-50f9d880a1ff)
